### PR TITLE
FIX: Turn isTemporal koders to non temporal when creating in bulk from terminal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "koders",
     "middlewares",
     "vimeo"
-  ]
+  ],
+  "editor.defaultFormatter": "standard.vscode-standard"
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -4,12 +4,12 @@ const conversor = require('conversor-numero-a-letras-es-ar')
 /**
  *
  * @param {Object} object - any object
- * removes falsy entries in an object
+ * removes falsy entries in an object, except if the value is an actual boolean
  */
 function removeFalsyEntries (object = {}) {
   return Object.entries(object)
     .reduce((objectData, [key, value]) => {
-      return !value
+      return (!value && (typeof value !== 'boolean'))
         ? objectData
         : { ...objectData, [key]: value }
     }, {})

--- a/tools/koders/bulk-load.js
+++ b/tools/koders/bulk-load.js
@@ -11,6 +11,7 @@ const db = require('../../src/lib/db')
 
 const generation = require('../../src/usecases/generation')
 const koder = require('../../src/usecases/koder')
+const dayjs = require('dayjs')
 
 async function main () {
   const {
@@ -46,7 +47,10 @@ async function main () {
       generation: {
         number: generationNumber,
         type: generationType
-      }
+      },
+      isActive: true,
+      isTemporal: false,
+      expirationDate: dayjs().add(100, 'years')
     }
   })
 


### PR DESCRIPTION
We were creating koders in bulk from the terminal using a csv file but once we added the isTemporal property to corntrol the temporal access we were not considering to turn to a full access the koders that are being enrolled, so this PR fixes it and when using bulk upload it changes the isTemporal, isActive and expirationDate to allow the recent enrolled koders to Sign in

