### PR TITLE
Fix duplicated id

### DIFF
--- a/.github/workflows/scheduled-class-upload.yml
+++ b/.github/workflows/scheduled-class-upload.yml
@@ -44,7 +44,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: Slack Notification
-        id: slack
         if: ${{ success() }}
         uses: slackapi/slack-github-action@v1.19.0
         with: 


### PR DESCRIPTION
Fix duplicated id

Error 

`The workflow is not valid. .github/workflows/scheduled-class-upload.yml (Line: 47, Col: 13): The identifier 'slack' may not be used more than once within the same scope.`