### PR TITLE
Add comment when creating a sirena lead

### DIFF
--- a/src/routes/sirena.js
+++ b/src/routes/sirena.js
@@ -14,7 +14,8 @@ router.post('/messages/first', async ctx => {
     phone,
     id,
     source,
-    campaignName
+    campaignName,
+    comments
   } = ctx.request.body
 
   if (!firstName) throw ctx.throw(400, 'firstName is required')
@@ -23,7 +24,7 @@ router.post('/messages/first', async ctx => {
   if (!email) throw ctx.throw(400, 'email is required')
   if (!phone) throw ctx.throw(400, 'phone is required')
 
-  await sendFirstMessage(firstName, lastName, phone, email, source, campaignName)
+  await sendFirstMessage(firstName, lastName, phone, email, source, campaignName, comments)
   await ac.deals.updateDealStage(id)
 
   ctx.resolve({

--- a/src/usecases/active-campaign/lists.js
+++ b/src/usecases/active-campaign/lists.js
@@ -12,7 +12,7 @@ async function subscribeContact (contactId, course) {
   const defaultJSList = 'default'
   const defaultPythonList = 'default'
   const finalGeneration = course.toLowerCase().includes('python')
-    ? defaultPythonList 
+    ? defaultPythonList
     : defaultJSList
 
   const defaultListId = ac.constants.lists['javascript-live'].default.id

--- a/src/usecases/sirena.js
+++ b/src/usecases/sirena.js
@@ -2,7 +2,7 @@ const createError = require('http-errors')
 const _ = require('lodash')
 const sirena = require('../lib/sirena')
 
-async function createLead (firstName, lastName, phone, email, source, campaignName) {
+async function createLead (firstName, lastName, phone, email, source, campaignName, comments = 'no comments') {
   const utmSource = campaignName || source || 'Desconocido'
   const phones = [phone]
   const emails = [email]
@@ -11,15 +11,16 @@ async function createLead (firstName, lastName, phone, email, source, campaignNa
     lastName,
     phones,
     emails,
-    utmSource
+    utmSource,
+    comments
   }
   const lead = await sirena.fetch('POST', '/lead/retail', body)
 
   return lead
 }
 
-async function sendFirstMessage (firstName, lastName, phone, email, source, campaignName) {
-  const leadData = await createLead(firstName, lastName, phone, email, source, campaignName)
+async function sendFirstMessage (firstName, lastName, phone, email, source, campaignName, comments) {
+  const leadData = await createLead(firstName, lastName, phone, email, source, campaignName, comments)
   const prospectId = _.get(leadData, 'id')
   const data = {
     key: sirena.constants.templates.firstMessage.id,


### PR DESCRIPTION

## Provides a way to add extra information when a lead is created in sirena

This has historically being achieved by adding a comment in zappier when a lead is beaing created... now that we are no longer using zappier to create lead and instead we are using our API and make this PR provides a way to add this type of comments to sirena

The old way in zappier
![Captura de Pantalla 2022-08-02 a la(s) 1 31 30](https://user-images.githubusercontent.com/7495937/182307350-27680cdc-860f-4195-9921-6ac12a12a1b7.png)


This is how it looks in sirena
![Captura de Pantalla 2022-08-02 a la(s) 1 27 48](https://user-images.githubusercontent.com/7495937/182306719-a9914796-3f21-41f6-9940-3c93e3f414e3.png)

Once this PR is merged we'll still need to make proper changes to kodemia´s make app